### PR TITLE
fix translate, change connection to self host

### DIFF
--- a/backend/Services/WordService.cs
+++ b/backend/Services/WordService.cs
@@ -47,7 +47,7 @@ public class WordService : IWordService
     {
         try
         {
-            var options = new LibreTranslateClientOptions("https://libretranslate.com", null);
+            var options = new LibreTranslateClientOptions("http://localhost:5000", null);
             using var client = new LibreTranslateClient(options, null);
 
             var result = await client.TranslateAsync(wordText, folder.Language, "en");


### PR DESCRIPTION
as mentioned in the previous PR, there was an issue with Libre translate hosting. now it works correctly with a self hosting setup. 

worth to mention, that for testing purposes words are translated only in english